### PR TITLE
added json to Gruntfile watch for assemble

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,7 +27,7 @@ module.exports = function(grunt) {
 
     watch: {
       assemble: {
-        files: ['<%= config.src %>/{data,templates}/{,*/}*.{md,hbs,yml}'],
+        files: ['<%= config.src %>/{data,templates}/{,*/}*.{md,hbs,yml,json}'],
         tasks: ['assemble']
       },
       sass: {


### PR DESCRIPTION
Added the .json file type to the watch task of the assemble portion of the Gruntfile in order to let changes to .json files trigger assemble and reload.