### PR TITLE
Fix readme markdow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Email Lab
+# Email Lab
 
 This a project for developing and testing email templates. It uses Grunt, a command-line build tool,
 to streamline and simplify the creation of email templates. Email template can be built with re-usable
@@ -8,7 +8,7 @@ styles required for HTML in most email clients.
 
 See the tools section below for more information.
 
-##Setup and Installation
+## Setup and Installation
 
 You will need the following tools installed in order to complete the setup (install notes are for Mac).
 
@@ -27,7 +27,7 @@ Once these are installed successfully complete the following steps to setup the 
 
 That's it! Sing and dance. The email template code is ready for development and testing.
 
-##Grunt
+## Grunt
 
 Grunt is a tool for automating workflow tasks. It is configured to easily preview, test and build your templates.
 
@@ -35,37 +35,37 @@ Grunt is a tool for automating workflow tasks. It is configured to easily previe
 - **Build** - Run `grunt` or `grunt build` to compile all your code for production into the `/dist` directory.
 - **Test** - Run `grunt send` to email your templates to a testing service like [Litmus](http://litmus.com/). To send just one email template use the template parameter like this `grunt send --template=order-confirmation` where the _template_ value is the basename of the template file. Use the `--to` parameter to provided a specific address to mail to (ie. `grunt send --to=me@example.com`).
 
-##Tools
+## Tools
 
 This Grunt workflow allows you to create emails like you would standard web pages, separating
 your HTML from your CSS.
 
-###Sass
+### Sass
 
 Node Sass is used to compile Sass files into standard CSS. Each email template will have it's own
 Sass file. Sass files are associated with specific templates simply by naming them with the same
 basename as the HTML template file for the email (ie. `contact-confirmation.html` --> `contact-confirmation.scss`).
 
-###Premailer
+### Premailer
 
 The [Premailer](https://github.com/dwightjack/grunt-premailer) plugin is used during builds to convert
 the styles from linked stylesheets into embedded and inlined styles in the template since email
 clients do not support linked stylesheets.
 
-###Nodemailer
+### Nodemailer
 
 The [Nodemailer](https://github.com/dwightjack/grunt-nodemailer) plugin is used to send your email
 templates to test email addresses for testing. You'll need to configure a nodemailer.json file
 to use the SMTP service from your Gmail address or other service. See `/settings.sample.json`
 for more details and a [list of supported SMTP services](https://github.com/andris9/nodemailer-wellknown#supported-services).
 
-###Handlebars/Assemble
+### Handlebars/Assemble
 
 [Handlerbars](http://handlebarsjs.com/) and [Assemble](http://assemble.io/) are used
 to dynamically build your templates with re-usable layouts. To create a new email
 template simply create a new file in `src/templates/emails` with the .hbs extension.
 
-##HTML Email Design
+## HTML Email Design
 
 This project provides some standard boilerplate HTML markup and styling for emails. We recommend checking out these
 other resources for additional layout templates and styling best practices:
@@ -75,7 +75,7 @@ other resources for additional layout templates and styling best practices:
 - [Mailchimp Email Design Reference](http://templates.mailchimp.com/) - Great reference guide for designing HTML emails
 - [Email Client Market Share](http://emailclientmarketshare.com/) - List of the most popular email clients
 
-##Todo
+## Todo
 
 - Create Yeoman generator that configures options, sets up Nodemailer and generates new email templates
 - Handle images locally during dev, but replace with hosted images for testing


### PR DESCRIPTION
The readme was not rendering headings correctly because the heading hashes did not have space before the heading text.