### PR TITLE
Update premailer gem to latest version (1.10.3)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "http://rubygems.org"
 
-gem 'premailer', '~> 1.8.3'
-gem 'nokogiri', '~> 1.6.6'
+gem 'premailer', '~> 1.10.3'
+gem 'nokogiri', '~> 1.7.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,26 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    addressable (2.3.7)
-    css_parser (1.3.6)
+    addressable (2.5.1)
+      public_suffix (~> 2.0, >= 2.0.2)
+    css_parser (1.5.0)
       addressable
-    htmlentities (4.3.1)
-    mini_portile (0.6.2)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
-    premailer (1.8.3)
-      css_parser (>= 1.3.6)
-      htmlentities (>= 4.0.0, <= 4.3.1)
+    htmlentities (4.3.4)
+    mini_portile2 (2.1.0)
+    nokogiri (1.7.1)
+      mini_portile2 (~> 2.1.0)
+    premailer (1.10.3)
+      addressable
+      css_parser (>= 1.4.10)
+      htmlentities (>= 4.0.0)
+    public_suffix (2.0.5)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  nokogiri (~> 1.6.6)
-  premailer (~> 1.8.3)
+  nokogiri (~> 1.7.1)
+  premailer (~> 1.10.3)
+
+BUNDLED WITH
+   1.14.6


### PR DESCRIPTION
Updates premailer and dependent nokogiri gem to latest stable versions.

This is related to an issue with styles being embedded in the body instead of the head. Looks like the latest version of premailer fixes this.

See issue #10.