### PR TITLE
feat: add docker support for development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:4-onbuild
+
+RUN \
+  apt-get update && \
+  apt-get install -y ruby && \
+  apt-get install -y ruby-dev
+
+RUN npm install -g grunt-cli
+
+RUN gem install bundler && bundle install
+
+WORKDIR /usr/src/app/
+
+EXPOSE 9000
+EXPOSE 35729

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -55,7 +55,7 @@ module.exports = function(grunt) {
         port: 9000,
         livereload: 35729,
         // change this to '0.0.0.0' to access the server from outside
-        hostname: 'localhost'
+        hostname: process.env.HOSTNAME || 'localhost'
       },
       livereload: {
         options: {

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ Once it finishes, you can access the email templates at http://localhost:9000/ i
 
 That's it! Sing and dance. The email template code is ready for development and testing.
 
+When you are done with development, you will want to remove the project from Docker.
+
+Run command `docker-compse down` to remove the docker container.
+
+
 ## Grunt
 
 Grunt is a tool for automating workflow tasks. It is configured to easily preview, test and build your templates.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,24 @@ Once these are installed successfully complete the following steps to setup the 
 
 That's it! Sing and dance. The email template code is ready for development and testing.
 
+## Setup and Installation with Docker
+
+You will need the following tools installed in order to complete the setup.
+
+- [Docker](https://www.docker.com)
+
+Once these are installed successfully complete the following steps to setup the project (run commands from the project root directory).
+
+1. Copy `settings.sample.json` to `settings.json` and configure the following:
+    - From email address
+    - Default To email address
+    - SMTP Provider settings (see a [full list of supported providers](https://github.com/andris9/nodemailer-wellknown#supported-services))
+1. Run the command `docker-compose up` to build and run the docker image.
+
+Once it finishes, you can access the email templates at http://localhost:9000/ in your browser.
+
+That's it! Sing and dance. The email template code is ready for development and testing.
+
 ## Grunt
 
 Grunt is a tool for automating workflow tasks. It is configured to easily preview, test and build your templates.
@@ -70,7 +88,7 @@ template simply create a new file in `src/templates/emails` with the .hbs extens
 This project provides some standard boilerplate HTML markup and styling for emails. We recommend checking out these
 other resources for additional layout templates and styling best practices:
 
-- [HTML Email Boilerplate](https://github.com/seanpowell/Email-Boilerplate) - Well-documented boilerplate template 
+- [HTML Email Boilerplate](https://github.com/seanpowell/Email-Boilerplate) - Well-documented boilerplate template
 - [Mailchimp Email Blueprints](https://github.com/mailchimp/Email-Blueprints) - Lots of template for various layouts, including responsive template
 - [Mailchimp Email Design Reference](http://templates.mailchimp.com/) - Great reference guide for designing HTML emails
 - [Email Client Market Share](http://emailclientmarketshare.com/) - List of the most popular email clients

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,6 @@ email-lab:
         - 35729:35729
     volumes:
         - ./src:/usr/src/app/src
-        - ./settings.sample.json:/usr/src/app/settings.json
+        - ./settings.json:/usr/src/app/settings.json
     environment:
         - HOSTNAME=0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+email-lab:
+    build: .
+    ports:
+        - 9000:9000
+        - 35729:35729
+    volumes:
+        - ./src:/usr/src/app/src
+        - ./settings.sample.json:/usr/src/app/settings.json
+    environment:
+        - HOSTNAME=0.0.0.0

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "node": ">=0.10.0",
     "npm": ">=1.3"
   },
+  "scripts": {
+    "start": "grunt server"
+  },
   "devDependencies": {
     "grunt": "~1.0.0",
     "grunt-assemble": "^0.4.0",


### PR DESCRIPTION
To simplify the workflow for our developers with different operating systems, we wanted to use Docker to bundle the dependencies for our email process.