### PR TITLE
chore: disable package-lock

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
#### Description 

Instead of ignoring `package-lock.json`, disables it from being generated using `.npmrc`. For more information check out [this article](https://codeburst.io/disabling-package-lock-json-6be662f5b97d)

#### To Validate
1. Pull down branch
2. Run `npm i`
3. Confirm that `package-lock.json` has not been generated